### PR TITLE
adds installation note for Mac OS X with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ On recent enough Debian systems:
 apt-get install kafkacat
 ````
 
+And on Mac OS X with homebrew installed:
+
+````
+brew install kafkacat
+````
+
 Otherwise follow directions below.
 
 


### PR DESCRIPTION
In the last couple of days i created two homebrew formulas for easy installation of kafkacat on Mac OS X. (the other formula is librdkafka and works as a dependency on kafkacat but can be installed standalone)
(for the formulas look here: https://github.com/Homebrew/homebrew/pull/39489 and here: https://github.com/Homebrew/homebrew/pull/39490)

Here's the pull request that adds the 'how to install'  to the readme for Mac OS X.