### PR TITLE
add the -l option, allows the producer to read and send delimited data from a file, just as with stdin

### DIFF
--- a/kafkacat.c
+++ b/kafkacat.c
@@ -331,8 +331,6 @@ static void producer_run (FILE *fp, char **paths, int pathcnt) {
                                 FATAL("Unable to read message: %s",
                                       strerror(errno));
                 }
-                if (fp != stdin)
-                        fclose(fp);
         }
 
         /* Wait for all messages to be transmitted */
@@ -1125,6 +1123,9 @@ int main (int argc, char **argv) {
                 usage(argv[0], 0, NULL);
                 break;
         }
+
+        if (in != stdin)
+                fclose(in);
 
         rd_kafka_wait_destroyed(5000);
 

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -61,6 +61,7 @@ struct conf {
 #define CONF_F_OFFSET     0x4 /* Print offsets */
 #define CONF_F_TEE        0x8 /* Tee output when producing */
 #define CONF_F_NULL       0x10 /* Send empty messages as NULL */
+#define CONF_F_LINE	  0x100 /* Read files in line mode when producing */
         int     delim;
         int     key_delim;
 

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -61,7 +61,7 @@ struct conf {
 #define CONF_F_OFFSET     0x4 /* Print offsets */
 #define CONF_F_TEE        0x8 /* Tee output when producing */
 #define CONF_F_NULL       0x10 /* Send empty messages as NULL */
-#define CONF_F_LINE	  0x100 /* Read files in line mode when producing */
+#define CONF_F_LINE	  0x20 /* Read files in line mode when producing */
         int     delim;
         int     key_delim;
 


### PR DESCRIPTION
This option makes it possible to use kafkacat as a log forwarder. I realize that the project wasn't developed with this in mind, and it requires a bit of special treatment in an init script to have it run as a daemon process. But we've been using it in production very successfully for over month, running stably under heavy loads, better than any alternative we could find.

We use it to forward data from Varnish log readers, among them the front-end proxies on a heavily-trafficked site, and kafkacat has managed over 6K messages/s well. The log readers write to a named pipe and kafkacat reads from there, so there's no file I/O involved. By comparison, logstash with the kafka output was creating so much CPU load that it was interfering with the proxy, and was also severely hampered by gc pauses. kafkacat consistently requires less than 1% of available CPU time.