### PR TITLE
Add %R format option to serialize payload size in raw format

### DIFF
--- a/format.c
+++ b/format.c
@@ -122,6 +122,9 @@ void fmt_parse (const char *fmt) {
                         case 'S':
                                 fmt_add(KC_FMT_PAYLOAD_LEN, NULL, 0);
                                 break;
+                        case 'R':
+                                fmt_add(KC_FMT_PAYLOAD_LEN_BINARY, NULL, 0);
+                                break;
                         case 't':
                                 fmt_add(KC_FMT_TOPIC, NULL, 0);
                                 break;
@@ -175,6 +178,7 @@ static void fmt_msg_output_str (FILE *fp,
 
         for (i = 0 ; i < conf.fmt_cnt ; i++) {
                 int r = 1;
+		uint64_t belen;
 
                 switch (conf.fmt[i].type)
                 {
@@ -211,6 +215,13 @@ static void fmt_msg_output_str (FILE *fp,
                         r = fprintf(fp, "%zd",
                                     /* Use -1 to indicate NULL messages */
                                     rkmessage->payload ? rkmessage->len : -1);
+			break;
+
+                case KC_FMT_PAYLOAD_LEN_BINARY:
+			belen = htobe64((uint64_t)(rkmessage->payload ? rkmessage->len : -1));
+			r = fwrite(&belen,
+                                    /* Use -1 to indicate NULL messages */
+				sizeof(uint64_t), 1, fp);
                         break;
 
                 case KC_FMT_STR:

--- a/format.c
+++ b/format.c
@@ -178,7 +178,7 @@ static void fmt_msg_output_str (FILE *fp,
 
         for (i = 0 ; i < conf.fmt_cnt ; i++) {
                 int r = 1;
-		uint32_t belen;
+                uint32_t belen;
 
                 switch (conf.fmt[i].type)
                 {
@@ -215,13 +215,12 @@ static void fmt_msg_output_str (FILE *fp,
                         r = fprintf(fp, "%zd",
                                     /* Use -1 to indicate NULL messages */
                                     rkmessage->payload ? rkmessage->len : -1);
-			break;
+                        break;
 
                 case KC_FMT_PAYLOAD_LEN_BINARY:
-			belen = htonl((uint32_t)(rkmessage->payload ? rkmessage->len : -1));
-			r = fwrite(&belen,
-                                    /* Use -1 to indicate NULL messages */
-				sizeof(uint32_t), 1, fp);
+                        /* Use -1 to indicate NULL messages */
+                        belen = htonl((uint32_t)(rkmessage->payload ? rkmessage->len : -1));
+                        r = fwrite(&belen, sizeof(uint32_t), 1, fp);
                         break;
 
                 case KC_FMT_STR:

--- a/format.c
+++ b/format.c
@@ -178,7 +178,7 @@ static void fmt_msg_output_str (FILE *fp,
 
         for (i = 0 ; i < conf.fmt_cnt ; i++) {
                 int r = 1;
-		uint64_t belen;
+		uint32_t belen;
 
                 switch (conf.fmt[i].type)
                 {
@@ -218,10 +218,10 @@ static void fmt_msg_output_str (FILE *fp,
 			break;
 
                 case KC_FMT_PAYLOAD_LEN_BINARY:
-			belen = htobe64((uint64_t)(rkmessage->payload ? rkmessage->len : -1));
+			belen = htonl((uint32_t)(rkmessage->payload ? rkmessage->len : -1));
 			r = fwrite(&belen,
                                     /* Use -1 to indicate NULL messages */
-				sizeof(uint64_t), 1, fp);
+				sizeof(uint32_t), 1, fp);
                         break;
 
                 case KC_FMT_STR:

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -877,6 +877,8 @@ static void __attribute__((noreturn)) usage (const char *argv0, int exitcode,
                "Format string tokens:\n"
                "  %%s                 Message payload\n"
                "  %%S                 Message payload length (or -1 for NULL)\n"
+               "  %%R                 Message payload length (or -1 for NULL) serialized\n"
+               "                     as a big endian 32bits signed integer\n"
                "  %%k                 Message key\n"
                "  %%K                 Message key length (or -1 for NULL)\n"
                "  %%t                 Topic\n"

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -878,7 +878,7 @@ static void __attribute__((noreturn)) usage (const char *argv0, int exitcode,
                "  %%s                 Message payload\n"
                "  %%S                 Message payload length (or -1 for NULL)\n"
                "  %%R                 Message payload length (or -1 for NULL) serialized\n"
-               "                     as a big endian 32bits signed integer\n"
+               "                     as a binary big endian 32-bit signed integer\n"
                "  %%k                 Message key\n"
                "  %%K                 Message key length (or -1 for NULL)\n"
                "  %%t                 Topic\n"

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -44,6 +44,7 @@ typedef enum {
         KC_FMT_KEY_LEN,
         KC_FMT_PAYLOAD,
         KC_FMT_PAYLOAD_LEN,
+        KC_FMT_PAYLOAD_LEN_BINARY,
         KC_FMT_TOPIC,
         KC_FMT_PARTITION,
 } fmt_type_t;


### PR DESCRIPTION
To simplify RLE decoder, add a %R formater for payload length so it
is serialied as a 64 bits big-endian integer.