### PR TITLE
Added list metadata for consumergroups with watermarks & stored offsets

### DIFF
--- a/kafkacat.c
+++ b/kafkacat.c
@@ -768,7 +768,7 @@ static void list_metadata_for_consumergroup() {
 }
 
 static void metadata_print_consumergroup(const rd_kafka_metadata_t *metadata, rd_kafka_t *rk) {
-        int i, j;
+        int i, j, jj;
 
         printf("Metadata for %s (from broker %"PRId32": %s):\n", conf.topic ? : "all topics",
                         metadata->orig_broker_id, metadata->orig_broker_name);
@@ -814,7 +814,7 @@ static void metadata_print_consumergroup(const rd_kafka_metadata_t *metadata, rd
                                 printf(" (try again)");
                 }
                 /* Iterate topic's partitions */
-                for (int jj = 0; jj < t->partition_cnt; jj++) {
+                for (jj = 0; jj < t->partition_cnt; jj++) {
                         j = reordered[runner + jj];
                         const rd_kafka_metadata_partition_t *p;
                         p = &t->partitions[j];

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -828,7 +828,7 @@ static void periodically_print_consumergroup_offset_totals(const struct conf* co
                                                 - totalsring[prev_totals_i].highwm);
                                 delta.stored = (totalsring[totals_i].stored
                                                 - totalsring[prev_totals_i].stored);
-                                printf("%8li %8.1f %8li %8.1f %8li %8.1f %8li %8.1f\n",
+                                printf("%8"PRId64" %8.1f %8"PRId64" %8.1f %8"PRId64" %8.1f %8"PRId64" %8.1f\n",
                                                 totalsring[totals_i].lowwm,
                                                 (double) delta.lowwm / (double) delta.time_s,
                                                 totalsring[totals_i].stored,
@@ -838,14 +838,14 @@ static void periodically_print_consumergroup_offset_totals(const struct conf* co
                                                 totalsring[totals_i].lag,
                                                 (double) delta.lag / (double) delta.time_s);
                         } else {
-                                printf("%8li %8.1f %8li %8.1f %8li %8.1f %8li %8.1f\n",
+                                printf("%8"PRId64" %8.1f %8"PRId64" %8.1f %8"PRId64" %8.1f %8"PRId64" %8.1f\n",
                                                 totalsring[totals_i].lowwm, (double) -1,
                                                 totalsring[totals_i].stored, (double) -1,
                                                 totalsring[totals_i].highwm, (double) -1,
                                                 totalsring[totals_i].lag, (double) -1);
                         }
                 } else {
-                        printf("%8li          %8li          %8li          %8li         \n",
+                        printf("%8"PRId64"          %8"PRId64"          %8"PRId64"          %8"PRId64"         \n",
                                         totalsring[totals_i].lowwm,
                                         totalsring[totals_i].stored,
                                         totalsring[totals_i].highwm,

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -744,10 +744,11 @@ static void metadata_print (const rd_kafka_metadata_t *metadata) {
 #include <stdio.h>
 #include <time.h>
 
+
 int64_t get_current_time_in_s()
 {
     struct timespec spec;
-    clock_gettime(CLOCK_REALTIME, &spec);
+    clock_gettime(0, &spec); // CLOCK_REALTIME is 0
     return spec.tv_sec;// * 1000 + round(spec.tv_nsec / 1.0e6);
 }
 

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -77,6 +77,7 @@ struct conf {
         char   *topic;
         int32_t partition;
         char   *group;
+        int    metadata_interval_seconds;
         int64_t offset;
         int     exit_eof;
         int64_t msg_cnt;


### PR DESCRIPTION
- removed high-level-consumer as a mode.
  downgraded -G to -g as a switch in -C and -L modes.
  - added metadata-list mode for consumergroups
    with detection of watermarks and stored offsets.
