### PR TITLE
load/store individual offsets for all the partitions from/to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,9 @@ Pretty-printed JSON metadata listing
 Query offset(s) by timestamp(s)
 
     $ kafkacat -b mybroker -Q -t mytopic:3:2389238523  mytopic2:0:18921841
+
+Use special partition index file in consumer mode
+
+    $ kafkacat -C -b mybroker -t syslog -I offsets.file ...
+
+Index file format is partition_id:offset for each partition

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -101,6 +101,7 @@ struct conf {
         rd_kafka_topic_t      *rkt;
 
         char   *debug;
+        char const *index_file;
 };
 
 extern struct conf conf;


### PR DESCRIPTION
The current implementation doesn't allow use of particular offsets for each partition. The patch fixes that using an external text file as an offset storage.