### PR TITLE
Add build and usage alternative with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.6
+
+RUN apk add --update alpine-sdk bash python cmake; \
+    curl https://codeload.github.com/edenhill/kafkacat/tar.gz/master | tar xzf - && cd kafkacat-* && bash ./bootstrap.sh; \
+    mv /kafkacat-master/kafkacat /usr/local/bin/; \
+    rm -rf /kafkacat-master
+ENTRYPOINT ["kafkacat"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ dependencies.
 
     ./bootstrap.sh
 
+## Build within docker
+
+As an alternative, build a docker image with kafkacat.
+
+````
+docker build -t kafkacat .
+````
+
+Now it is possible to use kafkacat over the docker image.
+
+````
+docker run --rm -it kafkacat <options> [file1 file2 .. | topic1 topic2 ..]]
+````
 
 # Examples
 


### PR DESCRIPTION
I've added an alternative way to build and use kafkacat with docker. So it possible to use kafkacat independently of the operation system. 