### PR TITLE
Support binary input mode for producing from stdin

### DIFF
--- a/kafkacat.c
+++ b/kafkacat.c
@@ -307,7 +307,44 @@ static void producer_run (FILE *fp, char **paths, int pathcnt) {
                 else if (good < pathcnt)
                         KC_INFO(1, "Failed to produce from %i/%i files\n",
                              pathcnt - good, pathcnt);
+        } else if (conf.flags & CONF_F_BINARY) {
+                /* Read message from input, entire input is a single message. */
+                const size_t buffer_size = 1024;
 
+                int msgflags = 0;
+                size_t read_size = 0;
+                sbuf = malloc(buffer_size);
+                if (!sbuf)
+                        KC_FATAL("Failed to allocate message: %s", strerror(errno));
+
+                while ((read_size = fread(sbuf + size, 1, buffer_size, fp)) == buffer_size) {
+                        size += read_size;
+                        sbuf = realloc(sbuf, size + buffer_size);
+                        if (!sbuf)
+                                KC_FATAL("Failed to allocate message: %s", strerror(errno));
+                }
+                size += read_size;
+
+                if (!feof(fp))
+                        KC_FATAL("Unable to read message: %s", strerror(errno));
+
+                if (size > 1024) {
+                        /* If message is larger than this arbitrary threshold
+                         * it will be more effective to not copy the data but
+                         * let rdkafka own it instead. */
+                        msgflags |= RD_KAFKA_MSG_F_FREE;
+                } else {
+                        /* For smaller messages a copy is more efficient. */
+                        msgflags |= RD_KAFKA_MSG_F_COPY;
+                }
+
+                produce(sbuf, size, NULL, 0, msgflags);
+
+                if (msgflags & RD_KAFKA_MSG_F_FREE) {
+                        /* rdkafka owns the allocated buffer memory now. */
+                        sbuf  = NULL;
+                        size = 0;
+                }
         } else {
                 /* Read messages from input, delimited by conf.delim */
                 while (conf.run &&
@@ -955,6 +992,8 @@ static void RD_NORETURN usage (const char *argv0, int exitcode,
                 "  -l                 Send messages from a file separated by\n"
                 "                     delimiter, as with stdin.\n"
                 "                     (only one file allowed)\n"
+                "  -B                 Read message from stdin in binary mode.\n"
+                "                     The entire input will be sent as one message.\n"
                 "  -T                 Output sent messages to stdout, acting like tee.\n"
                 "  -c <cnt>           Exit after producing this number "
                 "of messages\n"
@@ -1348,7 +1387,7 @@ static void argparse (int argc, char **argv,
         int do_conf_dump = 0;
 
         while ((opt = getopt(argc, argv,
-                             "PCG:LQt:p:b:z:o:eED:K:k:Od:qvF:X:c:Tuf:ZlVh"
+                             "PCG:LQt:p:b:z:o:eED:K:k:Od:qvF:X:c:Tuf:ZlBVh"
 #if ENABLE_JSON
                              "J"
 #endif
@@ -1434,6 +1473,9 @@ static void argparse (int argc, char **argv,
                         break;
                 case 'l':
                         conf.flags |= CONF_F_LINE;
+                        break;
+                case 'B':
+                        conf.flags |= CONF_F_BINARY;
                         break;
                 case 'O':
                         conf.flags |= CONF_F_OFFSET;

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -83,6 +83,7 @@ struct conf {
 #define CONF_F_APIVERREQ_USER 0x80 /* User set api.version.request */
 #define CONF_F_NO_CONF_SEARCH 0x100 /* Disable default config file search */
 #define CONF_F_BROKERS_SEEN 0x200 /* Brokers have been configured */
+#define CONF_F_BINARY     0x400 /* Read stdin in binary mode */
         int     delim;
         int     key_delim;
 


### PR DESCRIPTION
Suppose we have a program that produces some kind of binary output. We would like to be able to pipe the output of this program to kafkacat so that the binary output is created as a single message to kafka. However when kafkacat reads from stdin it assumes the input is delimited, and thus may split the input into multiple messages no matter what delimiter we choose. We can work around this by saving the output of the program to a file first and have kafkacat read from the file, but this requires an extra roundtrip to a file on disk. To avoid this extra step I'd like to propose a new binary mode for reading from stdin that treats the entire input as one message. Using this mode we can pipe the output directly to kafka using `create-binary-output | kafkacat -B`. Hopefully the idea seems sound to you. If you decide to incorporate something like this we can change the name of the switch, its description, etc. to your liking.