### PR TITLE
Reproducibly build statically linked binaries in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ config.h
 Makefile.config
 tmp-bootstrap
 *.offset
+core
+core.*
+vgcore.*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 kafkacat
 ========
-Copyright (c) 2014-2016 Magnus Edenhill
+Copyright (c) 2014-2018 Magnus Edenhill
 
 [https://github.com/edenhill/kafkacat](https://github.com/edenhill/kafkacat)
 
@@ -110,6 +110,12 @@ Read the last 100 messages from topic 'syslog' with  librdkafka configuration pa
 
     $ kafkacat -C -b mybroker -X broker.version.fallback=0.8.2.1 -t syslog -p 0 -o -100 -e
 
+
+Produce a tombstone (a "delete" for compacted topics) for key "abc" by providing an empty message value which `-Z` interpretes as NULL:
+
+    $ echo "abc:" | kafkacat -b mybroker -t mytopic -Z -K:
+
+
 Metadata listing
 
 ````
@@ -145,6 +151,7 @@ Pretty-printed JSON metadata listing
 Query offset(s) by timestamp(s)
 
     $ kafkacat -b mybroker -Q -t mytopic:3:2389238523 -t mytopic2:0:18921841
+
 
 # Running in docker
 

--- a/build_Dockerfile
+++ b/build_Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:trusty
+
+RUN apt-get update
+RUN apt-get install -y git curl gcc g++ make
+COPY . /kafkacat
+RUN cd /kafkacat && ./bootstrap.sh
+RUN strip /kafkacat/kafkacat

--- a/build_ubuntu_kafkacat.sh
+++ b/build_ubuntu_kafkacat.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker build -t=kafkacat:1.3.1 -f build_Dockerfile .
+docker cp $(docker create kafkacat:1.3.1):/kafkacat/kafkacat ./kafkacat
+echo "built binary ./kafkacat"

--- a/format.c
+++ b/format.c
@@ -192,7 +192,7 @@ static int print_headers (FILE *fp, const rd_kafka_headers_t *hdrs) {
         while (!rd_kafka_header_get_all(hdrs, idx++, &name, &value, &size)) {
                 fprintf(fp, "%s%s=", idx > 1 ? "," : "", name);
                 if (value && size > 0)
-                        fprintf(fp, "%.*s", (int)size, value);
+                        fprintf(fp, "%.*s", (int)size, (const char *)value);
                 else if (!value)
                         fprintf(fp, "NULL");
         }

--- a/json.c
+++ b/json.c
@@ -125,7 +125,8 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
 /**
  * Print metadata information
  */
-void metadata_print_json (const struct rd_kafka_metadata *metadata) {
+void metadata_print_json (const struct rd_kafka_metadata *metadata,
+                          int32_t controllerid) {
         yajl_gen g;
         int i, j, k;
         const unsigned char *buf;
@@ -149,6 +150,9 @@ void metadata_print_json (const struct rd_kafka_metadata *metadata) {
         JS_STR(g, "topic");
         JS_STR(g, conf.topic ? : "*");
         yajl_gen_map_close(g);
+
+        JS_STR(g, "controllerid");
+        yajl_gen_integer(g, (long long int)controllerid);
 
         /* Iterate brokers */
         JS_STR(g, "brokers");

--- a/json.c
+++ b/json.c
@@ -102,12 +102,19 @@ void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage) {
 
 
         JS_STR(g, "key");
-        yajl_gen_string(g, (const unsigned char *)rkmessage->key,
-                        rkmessage->key_len);
+        if (rkmessage->key)
+                yajl_gen_string(g, (const unsigned char *)rkmessage->key,
+                                rkmessage->key_len);
+        else
+                yajl_gen_null(g);
 
         JS_STR(g, "payload");
-        yajl_gen_string(g, (const unsigned char *)rkmessage->payload,
-                        rkmessage->len);
+        if (rkmessage->payload)
+                yajl_gen_string(g, (const unsigned char *)rkmessage->payload,
+                                rkmessage->len);
+        else
+                yajl_gen_null(g);
+
         yajl_gen_map_close(g);
 
         yajl_gen_get_buf(g, &buf, &len);

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -58,7 +58,7 @@ struct conf conf = {
         .partition = RD_KAFKA_PARTITION_UA,
         .msg_size = 1024*1024,
         .null_str = "NULL",
-        .fixed_key = NULL
+        .fixed_key = NULL,
         .flags = CONF_F_NO_CONF_SEARCH,
 };
 
@@ -938,7 +938,7 @@ static void RD_NORETURN usage (const char *argv0, int exitcode,
                 "  -F <config-file>   Read configuration properties from file,\n"
                 "                     file format is \"property=value\".\n"
                 "                     The KAFKACAT_CONFIG=path environment can "
-                "                     also be used, but -F takes preceedence.\n"
+                "also be used, but -F takes preceedence.\n"
                 "  -X list            List available librdkafka configuration "
                 "properties\n"
                 "  -X prop=val        Set librdkafka configuration property.\n"
@@ -1338,6 +1338,7 @@ static const char *kc_getenv (const char *env) {
         if (!(val = getenv(env)) || !*val)
                 return NULL;
         return val;
+#endif
 }
 
 static void read_default_conf_files (void) {

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -81,6 +81,8 @@ struct conf {
 #define CONF_F_LINE	  0x20 /* Read files in line mode when producing */
 #define CONF_F_APIVERREQ  0x40 /* Enable api.version.request=true */
 #define CONF_F_APIVERREQ_USER 0x80 /* User set api.version.request */
+#define CONF_F_NO_CONF_SEARCH 0x100 /* Disable default config file search */
+#define CONF_F_BROKERS_SEEN 0x200 /* Brokers have been configured */
         int     delim;
         int     key_delim;
 

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -49,6 +49,12 @@
 #define HAVE_HEADERS 0
 #endif
 
+#if RD_KAFKA_VERSION >= 0x000b0500
+#define HAVE_CONTROLLERID 1
+#else
+#define HAVE_CONTROLLERID 0
+#endif
+
 
 typedef enum {
         KC_FMT_STR,
@@ -152,7 +158,8 @@ void fmt_term (void);
  * json.c
  */
 void fmt_msg_output_json (FILE *fp, const rd_kafka_message_t *rkmessage);
-void metadata_print_json (const struct rd_kafka_metadata *metadata);
+void metadata_print_json (const struct rd_kafka_metadata *metadata,
+                          int32_t controllerid);
 void partition_list_print_json (const rd_kafka_topic_partition_list_t *parts,
                                 void *json_gen);
 void fmt_init_json (void);


### PR DESCRIPTION
Builds a statically linked kafkacat binary that runs on any ubuntu os versions.

new binary:
```
$ ldd kafkacat 
        linux-vdso.so.1 =>  (0x00007fffa274d000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2a7f634000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f2a7f32e000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2a7f12a000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f2a7ef22000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2a7eb59000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2a7fb4a000)
```

current binary pulled down from S3 (doesn't run on trusty):
```
$ ldd kafkacat
        linux-vdso.so.1 =>  (0x00007ffe2e7d8000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f126f4fa000)
        libssl.so.1.1 => not found
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f126f1f4000)
        libcrypto.so.1.1 => not found
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f126efdb000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f126edd7000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f126ebcf000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f126e806000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f126fa19000)
```