### PR TITLE
Use secure copyright file specification URI.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kafkacat (1.3.1-2) UNRELEASED; urgency=medium
+
+  * Use secure copyright file specification URI.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sun, 16 Sep 2018 09:12:13 +0100
+
 kafkacat (1.3.1-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: kafkacat
 Upstream-Contact: Magnus Edenhill <magnus@edenhill.se>
 Source: https://github.com/edenhill/kafkacat/


### PR DESCRIPTION
Use secure copyright file specification URI.

Fixes lintian: insecure-copyright-format-uri
See https://lintian.debian.org/tags/insecure-copyright-format-uri.html for more details.
