### PR TITLE
Allow to consume from/to given timestamps

### DIFF
--- a/kafkacat.c
+++ b/kafkacat.c
@@ -1525,7 +1525,7 @@ static void argparse (int argc, char **argv,
                                 if (!*rktparlistp)
                                         *rktparlistp = rd_kafka_topic_partition_list_new(1);
                                 add_topparoff("-t", *rktparlistp, optarg);
-
+                                conf.flags |= CONF_F_APIVERREQ;
                         } else
                                 conf.topic = optarg;
 

--- a/kafkacat.c
+++ b/kafkacat.c
@@ -640,7 +640,7 @@ static void consumer_run (FILE *fp) {
         /* Create consumer */
         if (!(conf.rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf.rk_conf,
                                      errstr, sizeof(errstr))))
-                KC_FATAL("Failed to create producer: %s", errstr);
+                KC_FATAL("Failed to create consumer: %s", errstr);
 
         if (!conf.debug && conf.verbosity == 0)
                 rd_kafka_set_log_level(conf.rk, 0);

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -126,6 +126,7 @@ struct conf {
         int64_t offset;
 #if RD_KAFKA_VERSION >= 0x00090300
         int64_t startts;
+        int64_t stopts;
 #endif
         int     exit_eof;
         int64_t msg_cnt;

--- a/kafkacat.h
+++ b/kafkacat.h
@@ -124,6 +124,9 @@ struct conf {
         char   *fixed_key;
         int32_t fixed_key_len;
         int64_t offset;
+#if RD_KAFKA_VERSION >= 0x00090300
+        int64_t startts;
+#endif
         int     exit_eof;
         int64_t msg_cnt;
         char   *null_str;

--- a/tools.c
+++ b/tools.c
@@ -57,10 +57,6 @@ int query_offsets_by_time (rd_kafka_topic_partition_list_t *offsets) {
 #if RD_KAFKA_VERSION >= 0x00090300
         char errstr[512];
 
-        if (rd_kafka_conf_set(conf.rk_conf, "api.version.request", "true",
-                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
-                KC_FATAL("Failed to enable api.version.request: %s", errstr);
-
         if (!(conf.rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf.rk_conf,
                                      errstr, sizeof(errstr))))
                 KC_FATAL("Failed to create producer: %s", errstr);


### PR DESCRIPTION
Hi @edenhill 

now tested
With this PR we can now do `kafkacat -o s@<startts> -o e@<stopts> ...`