### PR TITLE
Dockerfile for building static executable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 win32
 tmp-bootstrap
 rpm
+build
+meson/*
+!meson/*.wrap

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tmp-bootstrap
 core
 core.*
 vgcore.*
+build/
+meson/*
+!meson/*.wrap

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,22 @@
+project('kafkacat', 'c', version: '1.4.0', subproject_dir: 'meson')
+
+static = get_option('static')
+yajl = dependency('yajl', version: '>=2', required: get_option('json'), static: static, fallback: ['yajl', 'yajl_dep'])
+rdkafka = dependency('rdkafka', version: '>=0.9', static: static, fallback: ['rdkafka', 'rdkafka_dep'])
+
+conf = configuration_data()
+conf.set10('HAVE_YAJL', yajl.found())
+conf.set10('ENABLE_JSON', yajl.found() and get_option('json').enabled())
+conf.set10('ENABLE_KAFKACONSUMER', true)
+conf.set_quoted('KAFKACAT_VERSION', meson.project_version())
+configure_file(configuration: conf, output: 'config.h')
+link_args = []
+if static
+	link_args += ['-static']
+endif
+
+executable('kafkacat',
+	sources: ['format.c', 'json.c', 'kafkacat.c', 'kafkacat.h', 'rdport.h', 'tools.c'],
+	dependencies: [yajl, rdkafka],
+	link_args: link_args,
+)

--- a/meson/rdkafka.wrap
+++ b/meson/rdkafka.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = librdkafka-1.0.1
+
+source_url = https://github.com/edenhill/librdkafka/archive/v1.0.1.tar.gz
+source_filename = rdkafka-1.0.1.tgz
+source_hash = b2a2defa77c0ef8c508739022a197886e0644bd7bf6179de1b68bdffb02b3550
+
+patch_url = https://github.com/jcaesar/crappywraps/releases/download/2/rdkafka-patch.tgz
+patch_filename = rdkafka-patch-dl.tgz
+patch_hash = b5e3a7aaef4846ecdc90f60e6493e04ab7a41b0d864617d6b22012ff09e0fdf4

--- a/meson/yajl.wrap
+++ b/meson/yajl.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = yajl-2.1.0
+
+source_url = https://github.com/lloyd/yajl/archive/2.1.0.tar.gz
+source_filename = yajl-2.1.0.tgz
+source_hash = 3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a
+
+patch_url = https://github.com/jcaesar/crappywraps/releases/download/1/yajl-patch.tgz
+patch_filename = yajl-patch-dl.tgz
+patch_hash = b7d104a586da43e86762cf705dfaba1c2409415665a0fb75b6d67b1e905e9280

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('json', type: 'feature', value: 'enabled')
+option('static', type: 'boolean', value: 'false')

--- a/static.Dockerfile
+++ b/static.Dockerfile
@@ -1,0 +1,54 @@
+ARG BOOTSTRAP
+FROM ${BOOTSTRAP:-alpine:3.7} as gentoo
+RUN apk --no-cache add gnupg tar wget xz strace
+
+WORKDIR /gentoo
+
+ARG ARCH=amd64
+ARG MICROARCH=amd64
+ARG SUFFIX=-uclibc-hardened
+ARG DIST="http://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds"
+ARG SIGNING_KEY="0xBB572E0E2D182910"
+
+RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \
+	&& wget -O- 'http://ha.pool.sks-keyservers.net/pks/lookup?op=get&options=mr&search='${SIGNING_KEY} | gpg --import \
+	&& STAGE3PATH="$(wget -O- "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
+	&& echo "STAGE3PATH:" $STAGE3PATH \
+	&& STAGE3="$(basename ${STAGE3PATH})" \
+	&& wget --progress=dot:giga "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
+	&& gpg --verify "${STAGE3}.DIGESTS.asc" \
+	&& awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \
+	&& tar xpf "${STAGE3}" --xattrs --numeric-owner \
+	&& sed -i -e 's/#rc_sys=""/rc_sys="docker"/g' etc/rc.conf \
+	&& echo 'UTC' > etc/timezone \
+	&& rm ${STAGE3}.DIGESTS.asc ${STAGE3}.CONTENTS ${STAGE3}
+
+FROM gentoo/portage:latest as portage
+FROM scratch as builder
+COPY --from=gentoo /gentoo/ /
+COPY --from=portage /usr/portage /usr/portage
+
+RUN true \
+	&& echo 'CONFIG_PROTECT="-*"' >>/etc/portage/make.conf \
+	&& echo 'USE="static static-libs"' >>/etc/portage/make.conf \
+	&& echo 'FEATURES="-sandbox -ipc-sandbox -network-sandbox -pid-sandbox -usersandbox"' >>/etc/portage/make.conf # can't sandbox in the sandbox \
+	&& sed -i '/^\/usr\/lib$/ d; /^\/lib$/ d;' /etc/ld.so.conf
+
+RUN emerge --unmerge openssh ssh \
+	&& emerge --autounmask-write --autounmask-continue --tree --verbose --update --deep --newuse \
+		--exclude='openssh ssh' \
+		--exclude='gzip bzip2 tar xz' \
+		--exclude='debianutils patch pinentry' \
+		kafkacat meson dev-util/ninja \
+		app-arch/zstd app-arch/lz4 dev-libs/cyrus-sasl
+
+COPY . /opt/kafkacat
+RUN cd /opt/kafkacat \
+	&& meson build --wrap-mode forcefallback -Ddefault_library=static -Dstatic=true \
+	&& ninja -C build kafkacat \
+	&& ldd build/kafkacat | grep -q 'not.*dynamic'
+
+FROM scratch
+USER 1000
+ENTRYPOINT ["/kafkacat"]
+COPY --from=builder /opt/kafkacat/build/kafkacat /


### PR DESCRIPTION
This is the "Look ma, no hands" kind of pull request. I neither expect nor want it to be accepted. Just saying "Hi, this exists". (And it's been requested before https://github.com/edenhill/kafkacat/issues/159 @jjlin.)

Short notes:
 - I did see https://github.com/edenhill/mklove/issues/20 but that alone won't help: yajl installs its static library to yajl_s and does not make that known to pkg-config. Yay. (Edit: Oh, you seem to be preparing to roll your own yajl anyway…)
 - The dockerfile is based on https://github.com/gentoo/gentoo-docker-images (with some slight modifications for my precarious network situation).
 - It'd be possible to pull this kind of thing outside of a gentoo docker container, but I think that would at least require writing wraps for lz4, zstd, and sasl, and then probably to use meson's cross compilation features. But I'm fuzzy on that part.