### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,13 @@ compiler:
 os:
   - linux
   - osx
-
+arch:
+  - amd64
+  - ppc64le
+matrix:
+   exclude:
+      - os: osx
+        arch: ppc64le
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq && sudo apt-get install -y libssl-dev libsasl2-dev libcurl4-openssl-dev libjansson-dev ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install openssl curl jansson ; fi


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/kafkacat/builds/191921572 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!