### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kafkacat (1.7.1-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Dec 2022 05:07:01 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kafkacat (1.7.1-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Dec 2022 05:07:01 -0000
+
 kafkacat (1.7.1-2) unstable; urgency=medium
 
   * Source-only upload.
@@ -101,4 +107,3 @@ kafkacat (1.1.0-1) unstable; urgency=medium
   * Initial release. Closes: #772011.
 
  -- Vincent Bernat <bernat@debian.org>  Thu, 04 Dec 2014 11:54:56 +0100
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ kafkacat (1.7.1-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Dec 2022 05:07:01 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 13),
                pkg-config,
                zlib1g-dev,
                libyajl-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/edenhill/kcat
 Vcs-Browser: https://github.com/edenhill/kcat/tree/debian
 Vcs-Git: https://github.com/edenhill/kcat.git -b debian

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/edenhill/kcat/issues
+Bug-Submit: https://github.com/edenhill/kcat/issues/new
+Repository-Browse: https://github.com/edenhill/kcat


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/8b7db59c-7259-4cc0-a5d1-d69583a3520a/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8b7db59c-7259-4cc0-a5d1-d69583a3520a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8b7db59c-7259-4cc0-a5d1-d69583a3520a/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/kafkacat/8b7db59c-7259-4cc0-a5d1-d69583a3520a.