### PR TITLE
Read one byte from fp to get it uptodate after read calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,4 @@ pressing `Ctrl-D`.
 
 Since the cluster runs all in memory, with no disk IO, it is quite suitable
 for performance testing.
+

--- a/README.md
+++ b/README.md
@@ -369,4 +369,3 @@ pressing `Ctrl-D`.
 
 Since the cluster runs all in memory, with no disk IO, it is quite suitable
 for performance testing.
-

--- a/kcat.c
+++ b/kcat.c
@@ -485,6 +485,14 @@ static void producer_run (FILE *fp, char **paths, int pathcnt) {
                 }
 
                 if (conf.run) {
+                        char buf;
+
+                        /*
+                         * inbuf_read_to_delimeter now uses read instead of
+                         * fread. Hence fp is not uptodate for eof checking.
+                         * Try to read 1 byte from fp to get it uptodate.
+                         */
+                        fread(&buf, 1, 1, fp);
                         if (!feof(fp))
                                 KC_FATAL("Unable to read message: %s",
                                          strerror(errno));


### PR DESCRIPTION
`inbuf_read_to_delimeter` now uses `read` instead of `fread`. Hence `fp` is not uptodate for eof checking.
Try to read 1 byte from `fp` to get it uptodate.