### PR TITLE
Allow ssl.endpoint.identification.algorithm config

### DIFF
--- a/kcat.c
+++ b/kcat.c
@@ -1802,10 +1802,6 @@ static int try_conf_set (const char *name, char *val,
  */
 static int try_java_conf_set (const char *name, const char *val,
                               char *errstr, size_t errstr_size) {
-        if (!strcmp(name, "ssl.endpoint.identification.algorithm"))
-                return 1; /* SSL server verification:
-                           * not supported by librdkafka: ignore for now */
-
         if (!strcmp(name, "sasl.jaas.config")) {
                 char sasl_user[128], sasl_pass[128];
                 if (sscanf(val,


### PR DESCRIPTION
**Problem**

kcat does not allow users to set the `ssl.endpoint.identification.algorithm` property in config files.

One can verify this behavior by creating a config file with `ssl.endpoint.identification.algorithm=<non_default_value>` and running `kcat -F <config_file> -X dump`

This causes friction for folks that wish to use config files and rely on (m)TLS but do not use CN/SAN based verification.

Note that one can specify the aforementioned config value via command line args.

**Background**

1. Commit 5a7d3baf88e8c6305be3ef8d011fdbe65ddc69a3 added support for config files however at the time librdkafka did not support this parameter at the time. (I presume that) because this is a option is commonly set in Java Kafka client properties files, the decision was made to have kcat silently filter this option when parsing config files.
2. Support for ssl.endpoint.identification.algorithm was added in librdkafka v1.1.0 back in 2019 however the default was set to none.
3. With the release of librdkafka v2.x, the default value of ssl.endpoint.identification.algorithm changed from `none` to `https` (enabling hostname verification).

I imagine this issue has gone unnoticed due to (2); folks tend not to notice that a TLS feature is _disabled_ until you enable it 😅.