### PR TITLE
Fix typos identified by lintian (spellintian)

### DIFF
--- a/input.c
+++ b/input.c
@@ -309,7 +309,7 @@ static void inbuf_split (struct inbuf *inbuf, size_t dof,
  *
  * @returns 0 on eof/error, else 1 inbuf is valid.
  */
-int inbuf_read_to_delimeter (struct inbuf *inbuf, FILE *fp,
+int inbuf_read_to_delimiter (struct inbuf *inbuf, FILE *fp,
                              struct buf **outbuf) {
         int read_size = MIN(1024, inbuf->max_size);
         int fd = fileno(fp);

--- a/input.h
+++ b/input.h
@@ -55,7 +55,7 @@ void buf_destroy (struct buf *buf);
 void inbuf_free_buf (void *buf, size_t size);
 void inbuf_init (struct inbuf *inbuf, size_t max_size,
                  const char *delim, size_t delim_size);
-int inbuf_read_to_delimeter (struct inbuf *inbuf, FILE *fp,
+int inbuf_read_to_delimiter (struct inbuf *inbuf, FILE *fp,
                              struct buf **outbuf);
 
 #endif

--- a/kcat.1
+++ b/kcat.1
@@ -50,7 +50,7 @@ In producer mode (
 ),
 .Nm
 reads messages from stdin, delimited with a configurable
-delimeter and produces them to the provided Kafka cluster, topic and
+delimiter and produces them to the provided Kafka cluster, topic and
 partition. In consumer mode (
 .Fl C
 ),

--- a/kcat.c
+++ b/kcat.c
@@ -422,7 +422,7 @@ static void producer_run (FILE *fp, char **paths, int pathcnt) {
 
                 /* Read messages from input, delimited by conf.delim */
                 while (conf.run &&
-                       !(at_eof = !inbuf_read_to_delimeter(&inbuf, fp, &b))) {
+                       !(at_eof = !inbuf_read_to_delimiter(&inbuf, fp, &b))) {
                         int msgflags = 0;
                         char *buf = b->buf;
                         char *key = NULL;
@@ -1392,7 +1392,7 @@ static void RD_NORETURN usage (const char *argv0, int exitcode,
                 "  -K <delim>         Delimiter to split input key and message\n"
                 "  -k <str>           Use a fixed key for all messages.\n"
                 "                     If combined with -K, per-message keys\n"
-                "                     takes precendence.\n"
+                "                     takes precedence.\n"
                 "  -H <header=value>  Add Message Headers "
                 "(may be specified multiple times)\n"
                 "  -l                 Send messages from a file separated by\n"

--- a/rpm/kcat.spec
+++ b/rpm/kcat.spec
@@ -16,7 +16,7 @@ kcat is a generic non-JVM producer and consumer for Apache Kafka >= 0.8,
 think of it as a netcat for Kafka.
 
 In producer mode kcat reads messages from stdin, delimited with a
-configurable delimeter (-D, defaults to newline), and produces them to the
+configurable delimiter (-D, defaults to newline), and produces them to the
 provided Kafka cluster (-b), topic (-t) and partition (-p).
 
 In consumer mode kcat reads messages from a topic and partition and prints


### PR DESCRIPTION
delimeter -> delimiter
precendence -> precedence