### PR TITLE
Add %x to -f

### DIFF
--- a/format.c
+++ b/format.c
@@ -136,6 +136,9 @@ void fmt_parse (const char *fmt) {
                                 fmt_add(KC_FMT_TIMESTAMP, NULL, 0);
                                 conf.flags |= CONF_F_APIVERREQ;
                                 break;
+                        case 'x':
+                                fmt_add(KC_FMT_PAYLOAD_HEX, NULL, 0);
+                                break;
 #if HAVE_HEADERS
                         case 'h':
                                 fmt_add(KC_FMT_HEADERS, NULL, 0);
@@ -440,6 +443,7 @@ static void fmt_msg_output_str (FILE *fp,
                                     rkmessage->key ? (ssize_t)rkmessage->key_len : -1);
                         break;
 
+                case KC_FMT_PAYLOAD_HEX:
                 case KC_FMT_PAYLOAD:
                         if (rkmessage->len) {
                                 if (conf.flags & CONF_F_FMT_AVRO_VALUE) {
@@ -472,6 +476,12 @@ static void fmt_msg_output_str (FILE *fp,
                                                    errstr, sizeof(errstr)) ==
                                             -1)
                                                 goto fail;
+                                } else if (conf.fmt[i].type == KC_FMT_PAYLOAD_HEX) {
+                                        size_t j;
+                                        r = fprintf(fp, "0x");
+                                        for (j = 0; j<rkmessage->len; j++)
+                                                r = fprintf(fp, "%x", ((uint8_t *)rkmessage->payload)[j]);
+
                                 } else
                                         r = fwrite(rkmessage->payload,
                                                    rkmessage->len, 1, fp);

--- a/kcat.h
+++ b/kcat.h
@@ -70,6 +70,7 @@ typedef enum {
         KC_FMT_KEY,
         KC_FMT_KEY_LEN,
         KC_FMT_PAYLOAD,
+        KC_FMT_PAYLOAD_HEX,
         KC_FMT_PAYLOAD_LEN,
         KC_FMT_PAYLOAD_LEN_BINARY,
         KC_FMT_TOPIC,


### PR DESCRIPTION
when using kcat to read messages that are in some form of binary encoding (ie. protobuf) it's a pain to get the payloads easily transferred to another place to parse them. outputting them as hex makes for a easy way to do so!

current implementation prefixes the output with `0x`, but happy to drop that based on your preference